### PR TITLE
implement global theming partially

### DIFF
--- a/lib/feature/category/categoryDetail/view/categories_detail_view.dart
+++ b/lib/feature/category/categoryDetail/view/categories_detail_view.dart
@@ -7,6 +7,7 @@ import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/models/category.dart';
 import 'package:book_app/product/routes/app_routes.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:book_app/product/widgets/container/book_info_container.dart';
 import 'package:book_app/product/widgets/progress_indicator.dart';
 import 'package:flutter/material.dart';
@@ -27,12 +28,8 @@ class BookCategoriesDetailPage extends StatelessWidget {
       },
       onPageBuilder: (BuildContext context, CategoryViewModel viewModel) {
         return Scaffold(
-          backgroundColor: AppColors.background,
-          appBar: AppBar(
+          appBar: CustomAppBar(
             title: Text(category.name),
-            backgroundColor: AppColors.transparent,
-            elevation: 0,
-            centerTitle: true,
           ),
           body: bookModel.isLoading
               ? CustomProgressIndicator(text: AppStrings.wait, indicatorColor: AppColors.green)

--- a/lib/feature/category/view/category_page_view.dart
+++ b/lib/feature/category/view/category_page_view.dart
@@ -4,6 +4,7 @@ import 'package:book_app/product/constants/app_colors.dart';
 import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/routes/app_routes.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:book_app/product/widgets/container/header_container.dart';
 import 'package:book_app/product/widgets/progress_indicator.dart';
 import 'package:flutter/material.dart';
@@ -22,8 +23,12 @@ class BookCategoryView extends StatelessWidget {
       onPageBuilder: (BuildContext context, CategoryViewModel viewModel) {
         final categoryViewModel = Provider.of<CategoryViewModel>(context);
         return Scaffold(
-          backgroundColor: AppColors.background,
-          appBar: buildAppbar(context),
+          appBar: const CustomAppBar(
+            automaticallyImplyLeading: false,
+            title: Text(
+              AppStrings.categories,
+            ),
+          ),
           body: categoryViewModel.isLoading
               ? CustomProgressIndicator(text: AppStrings.wait, indicatorColor: AppColors.green)
               : SafeArea(
@@ -36,21 +41,6 @@ class BookCategoryView extends StatelessWidget {
                 ),
         );
       },
-    );
-  }
-
-  AppBar buildAppbar(BuildContext context) {
-    return AppBar(
-      backgroundColor: AppColors.transparent,
-      elevation: 0,
-      centerTitle: true,
-      automaticallyImplyLeading: false,
-      title: Text(
-        AppStrings.categories,
-        style: context.textTheme.headlineSmall?.copyWith(
-          color: AppColors.white,
-        ),
-      ),
     );
   }
 }

--- a/lib/feature/detail/view/book_detail_view.dart
+++ b/lib/feature/detail/view/book_detail_view.dart
@@ -5,6 +5,7 @@ import 'package:book_app/product/constants/app_colors.dart';
 import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/models/book.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:book_app/product/widgets/container/paragraph_container.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -23,8 +24,11 @@ class BookDetailView extends StatelessWidget {
       },
       onPageBuilder: (BuildContext context, BookDetailViewModel viewModel) => Scaffold(
         floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
-        backgroundColor: AppColors.background,
-        appBar: buildAppbar(),
+        appBar: CustomAppBar(
+          title: Text(
+            book.title,
+          ),
+        ),
         body: Padding(
           padding: context.paddingLowHorizontal,
           child: Column(
@@ -65,17 +69,6 @@ class BookDetailView extends StatelessWidget {
       child: Icon(
         Icons.favorite,
         color: AppColors.darkWhite,
-      ),
-    );
-  }
-
-  AppBar buildAppbar() {
-    return AppBar(
-      backgroundColor: AppColors.transparent,
-      elevation: 0,
-      centerTitle: true,
-      title: Text(
-        book.title,
       ),
     );
   }

--- a/lib/feature/favorite/view/favorite_view.dart
+++ b/lib/feature/favorite/view/favorite_view.dart
@@ -5,6 +5,7 @@ import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/models/book.dart';
 import 'package:book_app/product/routes/app_routes.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -20,8 +21,12 @@ class FavoriteBooksView extends StatelessWidget {
         model.setContext(context);
       },
       onPageBuilder: (context, value) => Scaffold(
-        backgroundColor: AppColors.background,
-        appBar: buildAppbar(),
+        appBar: const CustomAppBar(
+          automaticallyImplyLeading: false,
+          title: Text(
+            AppStrings.myFavoriteBooks,
+          ),
+        ),
         body: SafeArea(
           child: ListView(
             children: [
@@ -191,18 +196,6 @@ class FavoriteBooksView extends StatelessWidget {
           size: 20,
           color: AppColors.green,
         ),
-      ),
-    );
-  }
-
-  AppBar buildAppbar() {
-    return AppBar(
-      backgroundColor: AppColors.background,
-      automaticallyImplyLeading: false,
-      elevation: 0,
-      centerTitle: true,
-      title: const Text(
-        AppStrings.myFavoriteBooks,
       ),
     );
   }

--- a/lib/feature/home/view/book_home_view.dart
+++ b/lib/feature/home/view/book_home_view.dart
@@ -9,6 +9,7 @@ import 'package:book_app/product/constants/svg_constants.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/models/book.dart';
 import 'package:book_app/product/routes/app_routes.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:book_app/product/widgets/container/book_info_container.dart';
 import 'package:book_app/product/widgets/progress_indicator.dart';
 import 'package:book_app/product/widgets/text/row_icon_text.dart';
@@ -36,8 +37,12 @@ class _BookHomeViewState extends State<BookHomeView> {
         final trendingBooks = homeViewModel.trendingBooks;
         final bestsellerBooks = homeViewModel.bestsellerBooks;
         return Scaffold(
-          backgroundColor: AppColors.background,
-          appBar: _buildAppBar(),
+          appBar: const CustomAppBar(
+            automaticallyImplyLeading: false,
+            title: Text(
+              AppStrings.discover,
+            ),
+          ),
           body: homeViewModel.isLoading
               ? CustomProgressIndicator(text: AppStrings.wait, indicatorColor: AppColors.green)
               : SingleChildScrollView(
@@ -232,21 +237,6 @@ class _BookHomeViewState extends State<BookHomeView> {
           ),
         ),
       ],
-    );
-  }
-
-  AppBar _buildAppBar() {
-    return AppBar(
-      automaticallyImplyLeading: false,
-      backgroundColor: AppColors.transparent,
-      elevation: 0,
-      centerTitle: true,
-      title: Text(
-        AppStrings.discover,
-        style: context.textTheme.headlineSmall?.copyWith(
-          color: AppColors.white,
-        ),
-      ),
     );
   }
 }

--- a/lib/feature/onboard/view/onboard_view.dart
+++ b/lib/feature/onboard/view/onboard_view.dart
@@ -22,7 +22,6 @@ class OnboardView extends StatelessWidget {
         model.init();
       },
       onPageBuilder: (BuildContext context, OnboardViewModel viewModel) => Scaffold(
-        backgroundColor: AppColors.background,
         body: Padding(
           padding: context.paddingNormal,
           child: Column(

--- a/lib/feature/search/view/book_search_view.dart
+++ b/lib/feature/search/view/book_search_view.dart
@@ -6,6 +6,7 @@ import 'package:book_app/product/constants/app_colors.dart';
 import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/extensions/context_extension.dart';
 import 'package:book_app/product/routes/app_routes.dart';
+import 'package:book_app/product/widgets/appbar/custom_appbar.dart';
 import 'package:book_app/product/widgets/container/book_info_container.dart';
 import 'package:book_app/product/widgets/textField/stadium_textfield.dart';
 import 'package:flutter/material.dart';
@@ -31,8 +32,12 @@ class _BookSearchViewState extends State<BookSearchView> {
       onPageBuilder: (BuildContext context, BookSearchViewModel viewModel) {
         final bookSearchViewModel = Provider.of<BookSearchViewModel>(context);
         return Scaffold(
-          backgroundColor: AppColors.background,
-          appBar: buildAppBar(),
+          appBar: const CustomAppBar(
+            automaticallyImplyLeading: false,
+            title: Text(
+              AppStrings.search,
+            ),
+          ),
           body: Column(
             children: [
               SearchBar(searchController: _searchController, bookSearchViewModel: bookSearchViewModel),
@@ -84,18 +89,6 @@ class _BookSearchViewState extends State<BookSearchView> {
           },
         ),
       ),
-    );
-  }
-
-  AppBar buildAppBar() {
-    return AppBar(
-      backgroundColor: AppColors.background,
-      automaticallyImplyLeading: false,
-      elevation: 0,
-      title: const Text(
-        AppStrings.search,
-      ),
-      centerTitle: true,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:book_app/feature/onboard/view/onboard_view.dart';
 import 'package:book_app/product/constants/app_strings.dart';
 import 'package:book_app/product/provider/app_provider.dart';
+import 'package:book_app/product/theme/app_theme.dart';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -18,10 +20,11 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: AppStrings.appName,
-      home: OnboardView(),
+      theme: AppTheme().theme,
+      home: const OnboardView(),
     );
   }
 }

--- a/lib/product/theme/app_theme.dart
+++ b/lib/product/theme/app_theme.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import '../constants/app_colors.dart';
+
+class AppTheme {
+  ThemeData get theme {
+    return ThemeData(
+      brightness: Brightness.dark,
+      appBarTheme: _appBarTheme,
+      scaffoldBackgroundColor: AppColors.background,
+    );
+  }
+
+  AppBarTheme get _appBarTheme => AppBarTheme(
+        backgroundColor: AppColors.transparent,
+        centerTitle: true,
+        elevation: 0,
+      );
+}

--- a/lib/product/widgets/appbar/custom_appbar.dart
+++ b/lib/product/widgets/appbar/custom_appbar.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final Widget? title;
+  final Widget? leading;
+  final List<Widget>? actions;
+  final bool? automaticallyImplyLeading;
+  final Color? backgroundColor;
+  final TextStyle? titleTextStyle;
+
+  const CustomAppBar({
+    super.key,
+    this.title,
+    this.leading,
+    this.actions,
+    this.automaticallyImplyLeading,
+    this.backgroundColor,
+    this.titleTextStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      automaticallyImplyLeading: automaticallyImplyLeading ?? true,
+      title: title,
+      titleTextStyle: titleTextStyle,
+      leading: leading,
+      actions: actions,
+      backgroundColor: backgroundColor,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}


### PR DESCRIPTION
Instead of specifying the properties of commonly used widgets every time, it would be better to globally control the theming of these widgets. This will reduce the code repetition. Same thing can be applied to other widgets like card  